### PR TITLE
Fix Mac OSX support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: julia
 os:
   - linux
-  # Failing for now.
-  # - osx
+  - osx
 julia:
   - 0.5
   - nightly

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -8,8 +8,7 @@ const cpcsrcdir = joinpath(BinDeps.depsdir(libf477),"src","f477")
 provides(SimpleBuild,
     (@build_steps begin
         ChangeDirectory(cpcsrcdir)
-        `make`
         `make install`            
-    end),libf477, os = :Unix)
+    end), libf477)
 
 @BinDeps.install Dict([(:libf477, :libf477)])

--- a/deps/src/f477/Makefile
+++ b/deps/src/f477/Makefile
@@ -1,17 +1,21 @@
-F477LIB = libf477.so
-all: $(F477LIB)
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+  F477LIB = libf477.dylib
+else
+  F477LIB = libf477.so
+endif
+
+all: install
+
+install: sharedlib
+	mkdir -p ../../usr/lib
+	cp $(F477LIB) ../../usr/lib
+
+sharedlib:  f477.o
+	$(CC) -Wall -fPIC -shared f477.o -o $(F477LIB)
 
 f477.o: f477.c
 	$(CC) -Wall -c -O2 -fPIC f477.c
 
-# linking to primesieve not neccessary unless we want functions from primesieve.
-libf477.so:  f477.o
-	gcc -Wall -shared -Wl,-soname,libf477.so f477.o -o $(F477LIB) \
-           -lc -L../../usr/lib/ -Wl,-rpath,'$(CURDIR)/../../usr/lib'
-
-install: $(F477LIB)
-	mkdir -p ../../usr/lib
-	cp $(F477LIB) ../../usr/lib
-
 clean:
-	-rm *.o *.so
+	-rm *.o *.so *.dylib

--- a/src/EGM96.jl
+++ b/src/EGM96.jl
@@ -1,6 +1,11 @@
-include("../deps/deps.jl")
-
 module EGM96
-  export undulation
-  include("f477.jl")
+
+    if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
+        include("../deps/deps.jl")
+    else
+        error("EGM96 not properly installed. Please run Pkg.build(\"EGM96\")")
+    end
+    
+    export undulation
+    include("f477.jl")
 end

--- a/src/f477.jl
+++ b/src/f477.jl
@@ -12,7 +12,7 @@ function module_init()
     @assert isfile(egm96_filename)
 
     # Initialize the f477 C library
-    ccall((:init_arrays, "libf477"),
+    ccall((:init_arrays, libf477),
         Void,
         (Cstring, Cstring),
         corrcoef_filename,
@@ -23,7 +23,7 @@ end
 module_init()
 
 function undulation(lat::Number, lon::Number)
-    return ccall((:undulation, "libf477"),
+    return ccall((:undulation, libf477),
         Float64,
         (Float64, Float64, Int, Int),
         deg2rad(lat), deg2rad(lon), 360, 361)


### PR DESCRIPTION
The name of the shared library needs to end in ".dylib" on Mac.
Previously, it was hardcoded to ".so".
